### PR TITLE
Improves `zaktag.ps1`

### DIFF
--- a/ZakTag/README.md
+++ b/ZakTag/README.md
@@ -14,3 +14,4 @@ This script will run through every release group in your Radarr library and tag 
 ## `ZakTag.ps1` usage
 
 * `pwsh zaktag.ps1`
+* `pwsh zaktag.ps1 -Verbose`

--- a/ZakTag/ZakTag.ps1
+++ b/ZakTag/ZakTag.ps1
@@ -1,41 +1,91 @@
+[CmdletBinding()]
+param (
+)
+
+#------------- DEFINE VARIABLES -------------#
+
 $radarrApiKey = ""
 $radarrUrl = ""
-$releaseGroups = New-Object System.Collections.Generic.List[System.Object]
 
-if ($PSVersionTable.PSVersion -notlike "7.*") {
-    throw "You need Powershell 7 to run this script"
+#------------- SCRIPT STARTS -------------#
+
+$releaseGroups = New-Object System.Collections.Generic.List[System.Object]
+$releaseGroupTagsOnly = New-Object System.Collections.Generic.List[System.Object]
+
+# Powershell version check
+if ($PSVersionTable.PSVersion -like "5.*") {
+    throw "You need at least Powershell 7 to run this script"
 }
 
+# Web headers to be sent with each request
 $webHeaders = @{
     "x-api-key" = $radarrApiKey
 }
 
-
+# Retrieve all movies
 $allMovies = Invoke-RestMethod -Uri "$($radarrUrl)/api/v3/movie" -Headers $webHeaders -Method Get -StatusCodeVariable apiStatusCode
 
-$releaseGroups.AddRange(($allmovies.moviefile.releasegroup | Select-Object -Unique))
+$allMoviesWithFiles = $allMovies | Where-Object {$_.hasFile -contains "True"}
 
+# Retrieve all existing tags
+$allExistingTags = Invoke-RestMethod -Uri "$($radarrUrl)/api/v3/tag" -Headers $webHeaders -Method Get -StatusCodeVariable apiStatusCode
+
+# Add all existing release groups to a list
+$releaseGroups.AddRange(($allMoviesWithFiles.moviefile.releasegroup | Sort-Object -Unique))
+
+Write-Verbose "Checking that tags exist. If this is your first time running this script it might take a while - depending on your library size."
+
+# Loop through each release group and check if the tag exists in Radarr
 foreach ($releaseGroup in $releaseGroups){
-
-    $allExistingTags = Invoke-RestMethod -Uri "$($radarrUrl)/api/v3/tag" -Headers $webHeaders -Method Get -StatusCodeVariable apiStatusCode
-
+    # Try to match existing tag labels with current release group
     if ($allExistingTags.label -notcontains $releaseGroup){
-
-        Write-Host "Tag with name $($releaseGroup) does not exist, creating one..."
+        Write-Verbose "Tag with name $($releaseGroup) does not exist, creating tag..."
 
         $Body = @{
             "label" = $releaseGroup
         } | ConvertTo-Json
 
-        $createTag = Invoke-RestMethod -Uri "$($radarrUrl)/api/v3/tag" -Headers $webHeaders -Method Post -StatusCodeVariable apiStatusCode -Body $Body -ContentType "application/json"
-
-        $allExistingTags = Invoke-RestMethod -Uri "$($radarrUrl)/api/v3/tag" -Headers $webHeaders -Method Get -StatusCodeVariable apiStatusCode
+        # Create tag with current release group in Radarr
+        Invoke-RestMethod -Uri "$($radarrUrl)/api/v3/tag" -Headers $webHeaders -Method Post -StatusCodeVariable apiStatusCode -Body $Body -ContentType "application/json" | Out-Null
     }
 }
 
-foreach ($tag in $allExistingTags){
-    $movies = $allmovies | Where-Object {$_.moviefile.releasegroup -contains $tag.label}
+# Retrieve tags again so it includes the newly added release group tags
+$updatedTags = Invoke-RestMethod -Uri "$($radarrUrl)/api/v3/tag" -Headers $webHeaders -Method Get -StatusCodeVariable apiStatusCode
 
-    $setTag = Invoke-RestMethod -Uri "$($radarrUrl)/api/v3/movie/editor" -Headers $webHeaders -Method Put -StatusCodeVariable apiStatusCode -ContentType "application/json" -Body "{`"movieIds`":[$($movies.ID -join ",")],`"tags`":[$($tag.id)],`"applyTags`":`"add`"}"
+# Loop through each existing tag and select release groups tags only to avoid including previously defined tags
+foreach ($releaseGroup in $releaseGroups){
+    $releaseGroupTagsOnly.Add(($updatedTags | Where-Object {$_.label -contains $releaseGroup}))
+    }
 
+
+Write-Verbose "Checking that existing movies have the correct tag, if the wrong tag is found it will be removed."
+
+# Loop through each movie
+foreach ($movie in $allMoviesWithFiles){
+    # Loop through each tag id in current movie
+    foreach ($tagId in $movie.tags){
+        # If tag id matches a release group tag, look up the tag information
+        if ($releaseGroupTagsOnly.id -contains $tagId){
+            $tagLookup = $releaseGroupTagsOnly | Where-Object {$_.id -contains $tagId}
+        }
+        # Check if the movie's release group matches the tag, otherwise remove it
+        if ($movie.movieFile.releasegroup -notlike $tagLookup.label){
+            Write-Verbose "Removing tag $($tagLookup.label) from $($movie.title)"
+            Invoke-RestMethod -Uri "$($radarrUrl)/api/v3/movie/editor" -Headers $webHeaders -Method Put -StatusCodeVariable apiStatusCode -ContentType "application/json" -Body "{`"movieIds`":[$($movie.id)],`"tags`":[$($tagLookup.id -join ",")],`"applyTags`":`"remove`"}" | Out-Null
+        }
+    }
+
+    $movieReleaseGroup = $movie.movieFile.releaseGroup
+    $releaseGroupTag = $releaseGroupTagsOnly | Where-Object {$_.label -contains $movieReleaseGroup}
+
+    if ($movie.tags -contains $releaseGroupTag.id){
+        Write-Verbose "$($movie.title) already has tag $($releaseGroupTag.label)"
+    }
+
+    else {
+        Write-Verbose "Adding tag $($releaseGroupTag.label) to $($movie.title)"
+
+        Invoke-RestMethod -Uri "$($radarrUrl)/api/v3/movie/editor" -Headers $webHeaders -Method Put -StatusCodeVariable apiStatusCode -ContentType "application/json" -Body "{`"movieIds`":[$($movie.id)],`"tags`":[$($releaseGroupTag.id)],`"applyTags`":`"add`"}" | Out-Null
+    }
 }


### PR DESCRIPTION
`zaktag.ps1` has been reworked to include a tag removal process if the movie tag does not match the file release name. This is useful whenever a library is upgraded and a movie is upgraded with a different release group.